### PR TITLE
Improve monitor compatibility with older GPUs

### DIFF
--- a/monitor/nvml.py
+++ b/monitor/nvml.py
@@ -47,7 +47,7 @@ def get_devices():
         minor = int(call(nvmlDeviceGetMinorNumber, handle))
         serial = call(nvmlDeviceGetSerial, handle)
         if serial is None:
-            serial = 'N/A';
+            serial = 'N/A'
         else:
             serial = serial.decode()
         name = call(nvmlDeviceGetName, handle).decode()


### PR DESCRIPTION
Monitor pod fails on not supported operations, e.g. 

Traceback (most recent call last):
  File "start_monitor.py", line 5, in <module>
    from monitor import loop, config
  File "/app/monitor/loop.py", line 12, in <module>
    from . import nvml, docker_stats, gpu_stats, sysinfo, config
  File "/app/monitor/gpu_stats.py", line 15, in <module>
    devices = nvml.get_devices()
  File "/app/monitor/nvml.py", line 48, in get_devices
    serial = call(nvmlDeviceGetSerial, handle).decode()
AttributeError: 'NoneType' object has no attribute 'decode'

While the device itself probably can be traversed via nvml.

nvidia-smi output:
[nvidia-smi.txt](https://github.com/riseml/monitor/files/1675045/nvidia-smi.txt)
